### PR TITLE
feat: limpiar favoritos al cerrar sesión

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -3,6 +3,7 @@
 import React, { createContext, useState, useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import { useFavorites } from "./FavoritesContext";
 
 // Create the context
 export const AuthContext = createContext();
@@ -115,6 +116,9 @@ useEffect(() => {
     setUserRole(null);
     setIsAuthenticated(false);
     setCurrentToken(null); // Clear token state to trigger interceptor removal
+    // Limpiar favoritos al cerrar sesión
+    const { dispatch } = useFavorites(); 
+    dispatch({ type: "SET_FAVORITES", payload: [] });
   };
 
   // Only render children when loading is complete

--- a/frontend/src/contexts/FavoritesContext.jsx
+++ b/frontend/src/contexts/FavoritesContext.jsx
@@ -18,6 +18,8 @@ const favoritesReducer = (state, action) => {
       return state.filter((id) => id !== action.payload);
     case "SET_FAVORITES":
       return action.payload; // Set the favorites directly
+    case "CLEAR_FAVORITES": 
+      return [];  
     default:
       return state;
   }
@@ -141,6 +143,12 @@ export const FavoritesProvider = ({ children }) => {
       addFavorite(productId);
     }
   };
+
+  useEffect(() => {
+    if (!usuario) {
+      dispatch({ type: "CLEAR_FAVORITES" }); // Limpia los favoritos cuando el usuario es null
+    }
+  }, [usuario]);
 
   return (
     <FavoritesContext.Provider


### PR DESCRIPTION
- Se agrega la importación de `useFavorites` en `AuthContext.jsx`.
- Se modifica la función `logout` para vaciar la lista de favoritos al cerrar sesión.
- Se agrega un nuevo tipo de acción `CLEAR_FAVORITES` en el reducer de favoritos.
- Se implementa un `useEffect` en `FavoritesContext.jsx` para limpiar los favoritos cuando el usuario es `null`.